### PR TITLE
feat: add lnode editor and LN mapping

### DIFF
--- a/wizard-library/foundation.ts
+++ b/wizard-library/foundation.ts
@@ -123,7 +123,7 @@ export type WizardFactory = () => Wizard;
 /** If `wizard === null`, close the current wizard, else queue `wizard`. */
 export interface WizardDetail {
   wizard: WizardFactory | null;
-  subwizard?: boolean;
+  subWizard?: boolean;
 }
 
 /** @returns a clone of `element` with attributes set to values from `attrs`. */

--- a/wizard-library/wizard-code-form.ts
+++ b/wizard-library/wizard-code-form.ts
@@ -53,7 +53,10 @@ export default class WizardCodeForm extends LitElement {
     }
 
     const request = this.wizardRequest as EditWizardRequest;
-    return wizards[request.element.tagName]?.edit(request.element);
+    return wizards[request.element.tagName]?.edit(
+      request.element,
+      request.subWizard,
+    );
   }
 
   onClosed(): void {

--- a/wizard-library/wizards/lnode.ts
+++ b/wizard-library/wizards/lnode.ts
@@ -19,12 +19,15 @@ import {
 import { Edit, Insert } from '@openscd/open-scd-core';
 import { OscdFilteredList } from '@openscd/oscd-filtered-list';
 
+import { ifDefined } from 'lit/directives/if-defined.js';
 import {
   Wizard,
   WizardActor,
   WizardInputElement,
   createElement,
+  getValue,
 } from '../foundation.js';
+import { patterns, maxLength } from './patterns.js';
 
 // global variables
 const selectedIEDs: string[] = [];
@@ -33,7 +36,7 @@ let isLogicalNodeInstance = true;
 /** Sorts selected `ListItem`s to the top and disabled ones to the bottom. */
 function compare(
   a: { anyLn: Element; childLNode: boolean; selected: boolean },
-  b: { anyLn: Element; childLNode: boolean; selected: boolean }
+  b: { anyLn: Element; childLNode: boolean; selected: boolean },
 ): number {
   if (a.childLNode !== b.childLNode) return a.childLNode ? -1 : 1;
 
@@ -42,34 +45,107 @@ function compare(
   return 0;
 }
 
+type RenderOptions = {
+  desc: string | null;
+  iedName: string | null;
+  ldInst: string | null;
+  prefix: string | null;
+  lnClass: string | null;
+  lnInst: string | null;
+  lnType: string | null;
+};
+
+export function renderLNodeWizard(options: RenderOptions): TemplateResult[] {
+  const iedAssigned = options.iedName !== 'None';
+
+  return [
+    html`<scl-wizarding-textfield
+      label="iedName"
+      .maybeValue=${options.iedName}
+      helper="Referenced IED"
+      helperPersistent
+      disabled
+    ></scl-wizarding-textfield>`,
+    html`<scl-wizarding-textfield
+      label="desc"
+      .maybeValue=${options.desc}
+      nullable
+    ></scl-wizarding-textfield>`,
+    html`<scl-wizarding-textfield
+      label="ldInst"
+      .maybeValue=${options.ldInst}
+      helper="Referenced Logical Device"
+      maxLength="${maxLength.ldInst}"
+      pattern="${patterns.ldInst}"
+      ?nullable="${!iedAssigned}"
+      ?disabled="${iedAssigned}"
+    ></scl-wizarding-textfield>`,
+    html`<scl-wizarding-textfield
+      label="prefix"
+      .maybeValue=${options.prefix}
+      helper="Logical Node Prefix"
+      maxLength="${maxLength.prefix}"
+      pattern="${patterns.prefix}"
+      ?nullable="${!iedAssigned}"
+      ?disabled="${iedAssigned}"
+    ></scl-wizarding-textfield>`,
+    html`<scl-wizarding-textfield
+      label="lnClass"
+      .maybeValue=${options.lnClass}
+      helper="Logical Node Class"
+      helperPersistent
+      required
+      disabled
+    ></scl-wizarding-textfield>`,
+    html`<scl-wizarding-textfield
+      label="lnInst"
+      .maybeValue=${options.lnInst}
+      helper="Logical Node Instance"
+      maxLength="${maxLength.lnInst}"
+      pattern="${patterns.lnInst}"
+      helperPersistent
+      ?disabled="${iedAssigned}"
+    ></scl-wizarding-textfield>`,
+    html`<scl-wizarding-textfield
+      label="lnType"
+      .maybeValue=${options.lnType}
+      helper="Logical Node Type"
+      helperPersistent
+      disabled
+    ></scl-wizarding-textfield>`,
+  ];
+}
+
 function logicalNodeParameters(anyLn: Element): {
   prefix: string;
   lnClass: string;
   inst: string;
   iedName: string;
   ldInst: string;
+  lnType: string;
 } {
   const prefix = anyLn.getAttribute('prefix') ?? '';
   const lnClass = anyLn.getAttribute('lnClass') ?? '';
   const inst = anyLn.getAttribute('inst') ?? '';
+  const lnType = anyLn.getAttribute('lnType') ?? '';
 
   const iedName = anyLn.closest('IED')?.getAttribute('name') ?? '';
   const ldInst = anyLn.closest('LDevice')?.getAttribute('inst') ?? '';
 
-  return { prefix, lnClass, inst, iedName, ldInst };
+  return { prefix, lnClass, inst, iedName, ldInst, lnType };
 }
 
 function allAnyLNs(doc: XMLDocument): Element[] {
   return Array.from(
     doc.querySelectorAll(
-      ':root > IED > AccessPoint > Server > LDevice > LN0, :root > IED > AccessPoint > Server > LDevice > LN'
-    )
+      ':root > IED > AccessPoint > Server > LDevice > LN0, :root > IED > AccessPoint > Server > LDevice > LN',
+    ),
   );
 }
 
 function anyLnObject(
   parent: Element,
-  anyLn: Element
+  anyLn: Element,
 ): { anyLn: Element; childLNode: boolean; selected: boolean } {
   const { iedName, ldInst, prefix, lnClass, inst } =
     logicalNodeParameters(anyLn);
@@ -88,7 +164,7 @@ function anyLnObject(
   if (childLNode) return { anyLn, childLNode, selected: true };
 
   const selected = Array.from(
-    parent.closest('Substation')?.querySelectorAll('LNode') ?? []
+    parent.closest('Substation')?.querySelectorAll('LNode') ?? [],
   ).some(child => {
     if (child.tagName !== 'LNode') return false;
     return (
@@ -115,7 +191,7 @@ function showLogicalNodeTypes(evt: Event, parent: Element): void {
   const button = evt.target as Button;
 
   const instanceFilter = button.parentElement!.parentElement!.querySelector(
-    '#instanceFilter'
+    '#instanceFilter',
   ) as Element;
 
   if (isLogicalNodeInstance) instanceFilter.classList.remove('hidden');
@@ -128,7 +204,7 @@ function showLogicalNodeTypes(evt: Event, parent: Element): void {
       ? // eslint-disable-next-line no-use-before-define
         renderInstances(parent)
       : renderTypicals(doc)}`,
-    lnFilterList(button)
+    lnFilterList(button),
   );
 }
 
@@ -163,13 +239,15 @@ function createSingleLNode(parent: Element, ln: Element): Insert | null {
     };
   }
 
-  const { iedName, ldInst, prefix, lnClass, inst } = logicalNodeParameters(ln);
+  const { iedName, ldInst, prefix, lnClass, inst, lnType } =
+    logicalNodeParameters(ln);
   const node = createElement(parent.ownerDocument, 'LNode', {
     iedName,
     ldInst,
     prefix,
     lnClass,
     lnInst: inst,
+    lnType,
   });
 
   return {
@@ -182,14 +260,14 @@ function createSingleLNode(parent: Element, ln: Element): Insert | null {
 function createAction(parent: Element): WizardActor {
   return (_: WizardInputElement[], wizard: Element): Edit[] => {
     const list = wizard.shadowRoot?.querySelector(
-      '#lnList'
+      '#lnList',
     ) as OscdFilteredList;
 
     const selectedLNs = (list.selected as ListItemBase[])
       .filter(item => !item.disabled)
       .map(item => item.value)
       .map(id => {
-        if (id.endsWith('LLN0')) return find(parent.ownerDocument, 'LN0', id);
+        if (id.endsWith('LN0')) return find(parent.ownerDocument, 'LN0', id);
         if (id.startsWith('#'))
           return find(parent.ownerDocument, 'LNodeType', id);
 
@@ -203,10 +281,69 @@ function createAction(parent: Element): WizardActor {
   };
 }
 
+function updateAction(element: Element): WizardActor {
+  return (inputs: WizardInputElement[]): Edit[] => {
+    const attributes: Record<string, string | null> = {};
+    const lNodeTypeKeys = [
+      'desc',
+      'iedName',
+      'ldInst',
+      'prefix',
+      'lnInst',
+      'lnType',
+    ];
+    lNodeTypeKeys.forEach(key => {
+      attributes[key] = getValue(inputs.find(i => i.label === key)!);
+    });
+
+    if (
+      lNodeTypeKeys.some(key => attributes[key] !== element.getAttribute(key))
+    ) {
+      return [{ element, attributes }];
+    }
+
+    return [];
+  };
+}
+
+function mapAction(element: Element): WizardActor {
+  let lnSelector = 'LN';
+  return (_: WizardInputElement[], wizard: Element): Edit[] => {
+    const list = wizard.shadowRoot?.querySelector(
+      '#lnList',
+    ) as OscdFilteredList;
+
+    if ((list.selected as ListItemBase).value.endsWith('LN0'))
+      lnSelector = 'LN0';
+
+    const selectedLN = find(element.ownerDocument, lnSelector, (list.selected as ListItemBase).value);
+
+    if (selectedLN) {
+      const { iedName, ldInst, prefix, inst, lnType } = logicalNodeParameters(selectedLN);
+      const attributes: Record<string, string | null> = {};
+      const lNodeTypeKeys = ['iedName', 'ldInst', 'prefix', 'lnInst', 'lnType'];
+
+      attributes.iedName = iedName;
+      attributes.ldInst = ldInst;
+      attributes.prefix = prefix;
+      attributes.lnInst = inst;
+      attributes.lnType = lnType;
+
+      if (
+        lNodeTypeKeys.some(key => attributes[key] !== element.getAttribute(key))
+      ) {
+        return [{ element, attributes }];
+      }
+    }
+
+    return [];
+  };
+}
+
 function filterIED(evt: Event, parent: Element): void {
   const iedFilterList = evt.target as OscdFilteredList;
   const ieds = (iedFilterList.selected as ListItemBase[]).map(
-    selection => selection.value
+    selection => selection.value,
   );
 
   // update global array selectedIEDs
@@ -216,17 +353,36 @@ function filterIED(evt: Event, parent: Element): void {
   render(renderInstances(parent), lnFilterList(evt.target as HTMLElement));
 }
 
+function filterIEDLN(evt: Event, parent: Element): void {
+  const iedFilterList = evt.target as OscdFilteredList;
+  const ieds = (iedFilterList.selected as ListItemBase[]).map(
+    selection => selection.value,
+  );
+
+  // update global array selectedIEDs
+  selectedIEDs.length = 0;
+  selectedIEDs.push(...ieds);
+
+  render(renderLNodeInstances(parent), lnFilterList(evt.target as HTMLElement));
+}
+
 function renderListItem(value: {
   anyLn: Element;
   childLNode: boolean;
   selected: boolean;
 }): TemplateResult {
   const { iedName, ldInst, prefix, lnClass, inst } = logicalNodeParameters(
-    value.anyLn
+    value.anyLn,
   );
 
+  let ln = identity(value.anyLn);
+
+  if (lnClass === 'LLN0') {
+    ln += '>>LN0';
+  }
+
   return html`<mwc-check-list-item
-    value="${identity(value.anyLn)}"
+    value="${ln}"
     twoline
     ?disabled=${value.selected}
     ?selected=${value.childLNode}
@@ -237,7 +393,7 @@ function renderListItem(value: {
 
 function renderTypicals(doc: XMLDocument): TemplateResult[] {
   return Array.from(
-    doc.querySelectorAll(':root > DataTypeTemplates > LNodeType')
+    doc.querySelectorAll(':root > DataTypeTemplates > LNodeType'),
   ).map(lNodeType => {
     const lnClass = lNodeType.getAttribute('lnClass');
     const id = lNodeType.getAttribute('id');
@@ -254,7 +410,22 @@ function renderInstances(parent: Element): TemplateResult[] {
 
   return allAnyLNs(doc)
     .filter(anyLn =>
-      selectedIEDs.includes(anyLn.closest('IED')?.getAttribute('name') ?? '')
+      selectedIEDs.includes(anyLn.closest('IED')?.getAttribute('name') ?? ''),
+    )
+    .map(anyLn => anyLnObject(parent, anyLn))
+    .sort(compare)
+    .map(renderListItem);
+}
+
+function renderLNodeInstances(parent: Element): TemplateResult[] {
+  const doc = parent.ownerDocument;
+  const lnClass = parent.getAttribute('lnClass');
+
+  return allAnyLNs(doc)
+    .filter(
+      anyLn =>
+        anyLn.getAttribute('lnClass') === lnClass &&
+        selectedIEDs.includes(anyLn.closest('IED')?.getAttribute('name') ?? ''),
     )
     .map(anyLn => anyLnObject(parent, anyLn))
     .sort(compare)
@@ -266,7 +437,7 @@ function renderIEDItems(parent: Element): TemplateResult[] {
 
   return Array.from(doc.querySelectorAll(':root > IED')).map(ied => {
     const [iedName, manufacturer] = ['name', 'manufacturer'].map(value =>
-      ied.getAttribute(value)
+      ied.getAttribute(value),
     );
 
     return html`<mwc-check-list-item
@@ -329,6 +500,74 @@ export function createLNodeWizard(parent: Element): Wizard {
           </div>
         </div>`,
       ],
+    },
+  ];
+}
+
+export function editLNodeWizard(element: Element, subWizard?: boolean): Wizard {
+  if (subWizard) {
+    const lnClass = element.getAttribute('lnClass');
+
+    return [
+      {
+        title: 'Map LN to LNode',
+        primary: {
+          icon: 'save',
+          label: 'save',
+          action: mapAction(element),
+        },
+        content: [
+          html`<div id="createLNodeWizardContent">
+            <style>
+              .hidden {
+                display: none;
+              }
+            </style>
+            <div style="display: flex; flex-direction: row;">
+              <div id="instanceFilter">
+                <mwc-icon-button-toggle
+                  ?on=${!selectedIEDs.length}
+                  style="position:absolute;top:8px;right:60px;"
+                  onicon="filter_list"
+                  officon="filter_list_off"
+                  @click="${showIEdFilterList}"
+                ></mwc-icon-button-toggle>
+                <oscd-filtered-list
+                  class="${classMap({ hidden: selectedIEDs.length })}"
+                  id="iedList"
+                  multi
+                  @selected="${(evt: Event) => filterIEDLN(evt, element)}"
+                  >${renderIEDItems(element)}</oscd-filtered-list
+                >
+              </div>
+              <oscd-filtered-list
+                id="lnList"
+                searchField.value="${ifDefined(ifDefined(lnClass))}"
+              ></oscd-filtered-list>
+            </div>
+          </div>`,
+        ],
+      },
+    ];
+  }
+
+  return [
+    {
+      title: 'Edit LNode',
+      primary: {
+        icon: 'edit',
+        label: 'Save',
+        action: updateAction(element),
+      },
+      content: renderLNodeWizard({
+        desc: element.getAttribute('desc'),
+        iedName: element.getAttribute('iedName'),
+        ldInst: element.getAttribute('ldInst'),
+        prefix: element.getAttribute('prefix'),
+        lnClass: element.getAttribute('lnClass'),
+        lnInst: element.getAttribute('lnInst'),
+        lnType: element.getAttribute('lnType'),
+      }),
     },
   ];
 }

--- a/wizard-library/wizards/patterns.ts
+++ b/wizard-library/wizards/patterns.ts
@@ -13,6 +13,9 @@ export const patterns = {
   normalizedString:
     '([\u0020-\u007E]|[\u0085]|[\u00A0-\uD7FF]|[\uE000-\uFFFD])*',
   name,
+  tName:
+    '([\u0020-\u007E]|[\u0085]|[\u00A0-\uD7FF]|[\uE000-\uFFFD])' +
+    '([\u0020-\u007E]|[\u0085]|[\u00A0-\uD7FF]|[\uE000-\uFFFD])*',
   nmToken,
   names: `${name}( ${name})*`,
   nmTokens: `${nmToken}( ${nmToken})*`,
@@ -21,7 +24,11 @@ export const patterns = {
   integer: '[+\\-]?[0-9]+([0-9]*)',
   alphanumericFirstUpperCase: '[A-Z][0-9,A-Z,a-z]*',
   alphanumericFirstLowerCase: '[a-z][0-9,A-Z,a-z]*',
+  alphanumericFirst: '[A-Z,a-z][0-9,A-Z,a-z]*',
+  ldInst: '[A-Za-z0-9][0-9A-Za-z_]*',
+  prefix: '[A-Za-z][0-9A-Za-z_]*',
   lnClass: '(LLN0)|[A-Z]{4,4}',
+  lnInst: '[0-9]{1,12}',
   abstractDataAttributeName:
     '((T)|(Test)|(Check)|(SIUnit)|(Oper)|(SBO)|(SBOw)|(Cancel)|[a-z][0-9A-Za-z]*)',
   cdc:
@@ -29,11 +36,24 @@ export const patterns = {
     '(WYE)|(DEL)|(SEQ)|(HMV)|(HWYE)|(HDEL)|(SPC)|(DPC)|(INC)|(ENC)|(BSC)|(ISC)|(APC)|(BAC)|' +
     '(SPG)|(ING)|(ENG)|(ORG)|(TSG)|(CUG)|(VSG)|(ASG)|(CURVE)|(CSG)|(DPL)|(LPL)|(CSD)|(CST)|' +
     '(BTS)|(UTS)|(LTS)|(GTS)|(MTS)|(NTS)|(STS)|(CTS)|(OTS)|(VSD)',
+  uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+  id: '\\S{1,255}',
+  path: '.+(/.+)*',
+  mappedDoName:
+    '(([A-Za-z][0-9A-Za-z_]{0,63})/([A-Za-z][0-9A-Za-z_]{0,63})/((LLN0|([A-Za-z][0-9A-Za-z_]{0,10})?[A-Z]{4}[0-9]{1,12})).)?([A-Z][0-9A-Za-z]{0,11}(.[a-z][0-9A-Za-z]*(([0-9]+))?)?)',
+  vlanid: '[0-9A-F]{3}',
+  vlanPriority: '[0-7]',
+  ipv4: '([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5]).([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5]).([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5]).([0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])',
+  ipv6: '([0-9a-f]{1,4}:){7}[0-9a-f]{1,4}',
 };
 
 export const maxLength = {
   cbName: 32,
   abstracDaName: 60,
+  ldInst: 64,
+  prefix: 11,
+  lnInst: 12,
+  dosName: 12,
 };
 
 export const predefinedBasicTypeEnum = [
@@ -94,3 +114,38 @@ export const functionalConstraintEnum = [
   'EX',
   'CO',
 ];
+
+export const attributeNameEnum = [
+  'T',
+  'Test',
+  'Check',
+  'SIUnit',
+  'Oper',
+  'SBO',
+  'SBOw',
+  'Cancel',
+  'Addr',
+  'PRIORITY',
+  'VID',
+  'APPID',
+  'TransportInUse',
+  'IPClassOfTraffic',
+  'IPv6FlowLabel',
+  'IPAddressLength',
+  'IPAddress',
+];
+
+export const tSpecServiceType = [
+  'Poll',
+  'Report',
+  'GOOSE',
+  'SMV',
+  'Wired',
+  'Internal',
+];
+
+export const tSCLFileType = ['SED', 'SCC'];
+
+export const tRightEnum = ['full', 'fix', 'dataflow'];
+
+export const tSmpMod = ['SmpPerPeriod', 'SmpPerSec', 'SecPerSmp'];

--- a/wizard-library/wizards/wizards.ts
+++ b/wizard-library/wizards/wizards.ts
@@ -29,7 +29,7 @@ import { editGseWizard } from './gse.js';
 import { iEDEditWizard } from './ied.js';
 import { lDeviceEditWizard } from './ldevice.js';
 import { createLineWizard, editLineWizard } from './line.js';
-import { createLNodeWizard } from './lnode.js';
+import { createLNodeWizard, editLNodeWizard } from './lnode.js';
 import { createLNodeTypeWizard } from './lnodetype.js';
 import {
   createPowerTransformerWizard,
@@ -61,6 +61,7 @@ import {
 
 type SclElementWizard = (
   element: Element,
+  subWizard?: boolean,
   instanceElement?: Element
 ) => Wizard | undefined;
 
@@ -319,7 +320,10 @@ export const wizards: Record<
     edit: emptyWizard,
     create: emptyWizard,
   },
-  LNode: { edit: emptyWizard, create: createLNodeWizard },
+  LNode: {
+    edit: editLNodeWizard,
+    create: createLNodeWizard
+  },
   LNodeType: {
     edit: emptyWizard,
     create: createLNodeTypeWizard,


### PR DESCRIPTION
Related to https://github.com/OpenEnergyTools/scl-substation-editor/issues/5

This pull request adds the LNode edit wizard, and provides a `Map LN to LNode` wizard which can be used within the [scl-substation-editor](https://github.com/OpenEnergyTools/scl-substation-editor) plugin.